### PR TITLE
Preemptively use `multiple = "all"` in `left_join()`

### DIFF
--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -237,7 +237,7 @@ prepare_all <- function(data_exposures,
   data_injuries <- check_injfollowup(followup_df, data_injuries)
 
   injd <- followup_df %>%
-    dplyr::left_join(data_injuries, by = c("player" = "player")) %>%
+    dplyr::left_join(data_injuries, by = c("player" = "player"), multiple = "all") %>%
     dplyr::arrange(.data$player, .data$t0, .data$date_injured)
 
   ## Create two variables of date type: tstart and tstop

--- a/tests/testthat/_snaps/prepare_data.md
+++ b/tests/testthat/_snaps/prepare_data.md
@@ -1,0 +1,8 @@
+# prepare_all works fine when dates in injury and exposure data do not match
+
+    Code
+      out <- prepare_all(data_exposures = data_exposures, data_injuries = df_injuries,
+        exp_unit = "matches_minutes")
+    Warning <simpleWarning>
+      Injury data has been cut to the given follow-up period (in exposure data)
+

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -81,12 +81,13 @@ test_that("prepare_all works fine when dates in injury and exposure data do not 
                               time_expo     = "minutes_played")
 
   data_exposures <- filter(df_exposures, date == 2018)
-  w <- capture_warnings(prepare_all(data_exposures = data_exposures,
-                                          data_injuries  = df_injuries,
-                                          exp_unit = "matches_minutes"))
-  expect_length(w, 1)
-  expect_match(w, regexp = "Injury data has been cut")
 
+  # Should have 1 warning
+  expect_snapshot({
+    out <- prepare_all(data_exposures = data_exposures,
+                       data_injuries  = df_injuries,
+                       exp_unit = "matches_minutes")
+  })
 })
 
 test_that("data_followup works as expected", {


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, we need to work around a broken test that was expecting a single warning.

I've done this by preemptively adding `multiple = "all"` to the join function, which doesn't do anything with CRAN dplyr but silences the warning in dev dplyr.

I've also switched you to a snapshot test, which should be more robust for checking this kind of thing (i.e. it won't fail on CRAN if that section of code starts throwing >1 warning all of a sudden, but will fail in your CI and locally).

We actually plan to submit dplyr 1.1.0 today. We typically give you more time to make changes, but we sent out most of these PRs a month ago and missed yours because injurytools made it to CRAN in mid January. Sorry about that!